### PR TITLE
Create hooks for PokeApi

### DIFF
--- a/src/api-types.ts
+++ b/src/api-types.ts
@@ -7,10 +7,10 @@ export interface PokeAPIAllPokemon {
     count:    number;
     next:     string;
     previous: null;
-    results:  Result[];
+    results:  PokemonListing[];
 }
 
-export interface Result {
+export interface PokemonListing {
     name: string;
     url:  string;
 }

--- a/src/components/PokemonAdder.tsx
+++ b/src/components/PokemonAdder.tsx
@@ -1,7 +1,8 @@
-import React, { useEffect, useState } from 'react';
+import React, { useState } from 'react';
 import { PokeAPIAllPokemon, PokeAPIPokemon } from '../api-types';
 import { PokemonType } from './Pokemon';
 import ReactSelect from 'react-select';
+import { useGetAllPokemon } from '../hooks/PokeApi';
 
 type SelectOption = {label: string, value: string};
 
@@ -14,20 +15,7 @@ const PokemonAdder: React.FC<Props> = ({ onAddToParty }) => {
     const [pokemonData, setPokemonData] = useState<PokeAPIPokemon>();
     const [nickname, setNickname] = useState<string>('');
     const [isLoading, setIsLoading] = useState(false);
-    const [allPokemon, setAllPokemon] = useState<PokeAPIAllPokemon['results']>([]);
-
-    useEffect(() => {
-        fetchAllPokemon();
-    }, []);
-
-    const fetchAllPokemon = async () => {
-        setIsLoading(true);
-        const endpoint = 'https://pokeapi.co/api/v2/pokemon';
-        const result: PokeAPIAllPokemon = await (await fetch(endpoint)).json();
-
-        setAllPokemon(result.results);
-        setIsLoading(false);
-    };
+    const { data: allPokemon, loading } = useGetAllPokemon();
 
     const clearData = () => {
         setPokemonData(undefined);
@@ -71,12 +59,14 @@ const PokemonAdder: React.FC<Props> = ({ onAddToParty }) => {
         return pokemon.map(({ name, url}) => ({ label: name, value: url }));
     };
 
-    const isButtonDisabled = !pokemonData || isLoading;
+    const isButtonDisabled = !pokemonData || isLoading || loading;
+
+    const allPokemonOptions = allPokemon && transformPokemonForReactSelect(allPokemon);
 
     return (
         <div>
             <div>
-                <ReactSelect value={selectedPokemon} options={transformPokemonForReactSelect(allPokemon)} isDisabled={!allPokemon} onChange={handleSearch}  />
+                <ReactSelect value={selectedPokemon} options={allPokemonOptions} isDisabled={!allPokemon} onChange={handleSearch}  />
             </div>
             <div>
                 <input placeholder="Nickname" onChange={({ target: { value } }) => setNickname(value)} value={nickname} />

--- a/src/components/PokemonAdder.tsx
+++ b/src/components/PokemonAdder.tsx
@@ -1,8 +1,8 @@
 import React, { useState } from 'react';
-import { PokeAPIAllPokemon, PokeAPIPokemon } from '../api-types';
+import { PokemonListing } from '../api-types';
 import { PokemonType } from './Pokemon';
 import ReactSelect from 'react-select';
-import { useGetAllPokemon } from '../hooks/PokeApi';
+import { useGetAllPokemon, useGetPokemonData } from '../hooks/PokeApi';
 
 type SelectOption = {label: string, value: string};
 
@@ -12,13 +12,11 @@ type Props = {
 
 const PokemonAdder: React.FC<Props> = ({ onAddToParty }) => {
     const [selectedPokemon, setSelectedPokemon] = useState<SelectOption | null>();
-    const [pokemonData, setPokemonData] = useState<PokeAPIPokemon>();
     const [nickname, setNickname] = useState<string>('');
-    const [isLoading, setIsLoading] = useState(false);
-    const { data: allPokemon, loading } = useGetAllPokemon();
+    const { data: allPokemon, loading: pokedexLoading } = useGetAllPokemon();
+    const [fetchPokemon, { data: pokemonData, loading: pokemonLoading }] = useGetPokemonData();
 
     const clearData = () => {
-        setPokemonData(undefined);
         setNickname('');
         setSelectedPokemon(null);
     };
@@ -28,14 +26,8 @@ const PokemonAdder: React.FC<Props> = ({ onAddToParty }) => {
     const handleSearch = async (e: unknown) => {
         if (!e) return;
         setSelectedPokemon(e as SelectOption);
-        const { value: endpoint } = e as SelectOption;
-
-        setIsLoading(true);
-
-        const repsonse: PokeAPIPokemon = await (await fetch(endpoint)).json();
-
-        setPokemonData(repsonse);
-        setIsLoading(false);
+        const { value: name } = e as SelectOption;
+        fetchPokemon(name);
     };
 
     const handleAddToParty = () => {
@@ -52,14 +44,14 @@ const PokemonAdder: React.FC<Props> = ({ onAddToParty }) => {
         clearData();
     };
 
-    const transformPokemonForReactSelect = (pokemon: PokeAPIAllPokemon['results']): SelectOption[] => {
+    const transformPokemonForReactSelect = (pokemon: PokemonListing[]): SelectOption[] => {
         if (!pokemon){
             return [];
         }
-        return pokemon.map(({ name, url}) => ({ label: name, value: url }));
+        return pokemon.map(({ name }) => ({ label: name, value: name }));
     };
 
-    const isButtonDisabled = !pokemonData || isLoading || loading;
+    const isButtonDisabled = pokemonLoading || pokedexLoading;
 
     const allPokemonOptions = allPokemon && transformPokemonForReactSelect(allPokemon);
 

--- a/src/hooks/PokeApi.ts
+++ b/src/hooks/PokeApi.ts
@@ -1,0 +1,39 @@
+import { useEffect, useState } from "react";
+import { PokeAPIAllPokemon, PokemonListing } from "../api-types";
+
+type Maybe<T> = T | undefined;
+type Error = {
+    message: string;
+};
+
+export const useGetAllPokemon: () => { 
+    data: Maybe<PokemonListing[]>, 
+    error: Maybe<Error>, 
+    loading: boolean, 
+} = () => {
+    const [data, setData] = useState<PokemonListing[]>();
+    const [error, setError] = useState<Error>();
+    const [loading, setLoading] = useState(true);
+
+    const fetchAllPokemon = async (onComplete?: () => void) => {
+        const endpoint = 'https://pokeapi.co/api/v2/pokemon?limit=2000';
+        const response: PokeAPIAllPokemon = await (await fetch(endpoint)).json();
+        if (onComplete) onComplete();
+        return response.results;
+    };
+
+    useEffect(() => {
+        setLoading(true);
+        try{
+            (async() => setData(await fetchAllPokemon(() => { setLoading(false) })))();
+        } catch (e) {
+            setError({ message: e.message });
+        }
+    }, []);
+
+    return {
+        loading,
+        error,
+        data,
+    };
+};


### PR DESCRIPTION
This PR adds the `useGetAllPokemon` and `useGetPokemonData` hooks for fetching data from the PokeApi endpoint.