### PR TITLE
Add more responsive breakpoints using css grid

### DIFF
--- a/src/components/Party.tsx
+++ b/src/components/Party.tsx
@@ -8,11 +8,16 @@ type Props = {
 };
 
 const Container = styled.div`
-    display: flex;
-    justify-content: space-around;
-    flex-direction: row;
-    @media screen and (max-width: 1300px) {
-        flex-wrap: wrap;
+    display: grid;
+    grid-template-columns: repeat(6, 1fr);
+    @media screen and (max-width: 400px) {
+        grid-template-columns: repeat(1, 1fr);
+    }
+    @media screen and (min-width: 400px) and (max-width: 800px) {
+        grid-template-columns: repeat(2, 1fr);
+    }
+    @media screen and (min-width: 800px) and (max-width: 1300px) {
+        grid-template-columns: repeat(3, 1fr);
     }
 `;
 


### PR DESCRIPTION
This PR adds the use of CSS Grid to control the layout of the party a bit nicer. Also added a few more breakpoints to make the app a bit more responsive.
Fixes #12

## Screenshots
<img width="1792" alt="Screen Shot 2020-11-07 at 9 44 16 am" src="https://user-images.githubusercontent.com/20939486/98421658-f1b58b00-20dd-11eb-80ec-21c6e2d2276c.png">
<img width="1092" alt="Screen Shot 2020-11-07 at 9 44 08 am" src="https://user-images.githubusercontent.com/20939486/98421665-f67a3f00-20dd-11eb-982c-ce79ccef3d28.png">
<img width="464" alt="Screen Shot 2020-11-07 at 9 43 56 am" src="https://user-images.githubusercontent.com/20939486/98421669-f9752f80-20dd-11eb-9f4b-af4697b89d17.png">
<img width="444" alt="Screen Shot 2020-11-07 at 9 43 48 am" src="https://user-images.githubusercontent.com/20939486/98421673-fb3ef300-20dd-11eb-902b-b5aeb9025dcc.png">
